### PR TITLE
Overload role equality

### DIFF
--- a/hyphen/roles.py
+++ b/hyphen/roles.py
@@ -18,6 +18,11 @@ class Role(BaseModel):
     def serialize(self) -> dict:
         return self.name
 
+    def __eq__(self, __value: object) -> bool:
+        if isinstance(__value, str):
+            return self.name == __value
+        return super().__eq__(__value)
+
 
 class LocalizedRole(BaseModel):
     roles: List[str]

--- a/tests/unit/test_roles.py
+++ b/tests/unit/test_roles.py
@@ -1,0 +1,11 @@
+from pytest import mark as m
+from hyphen.roles import Role
+
+@m.describe("Roles")
+class TestRole:
+
+    @m.it("should be equal to a string with the same value")
+    def test_role_equals_string(self):
+        role = Role(name="teamOwner", context="team", context_id="123")
+        assert role == "teamOwner"
+        assert not role == "teamMember"

--- a/tests/unit/test_roles.py
+++ b/tests/unit/test_roles.py
@@ -1,6 +1,7 @@
 from pytest import mark as m
 from hyphen.roles import Role
 
+
 @m.describe("Roles")
 class TestRole:
 


### PR DESCRIPTION
We do 
```
(role_string == role.name) or (role_string == role) 

```
a lot

now we do 
```
role_string == role
```
(overloaded equality)